### PR TITLE
feat: package macOS builds as DMG and fix release workflow

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -68,20 +68,26 @@ jobs:
           macdeployqt build/filterGenerator/filterGenerator.app -verbose=1
           macdeployqt build/filterGenerator/filterRuleTest.app -verbose=1
 
-      - name: Package
+      - name: Package as DMG
         id: set-artifact
         run: |
           ARTIFACT_NAME="filterGenerator-macos-arm64"
-          cd build/filterGenerator
-          tar -czf "../../${ARTIFACT_NAME}.tar.gz" filterGenerator.app filterRuleTest.app
+          mkdir -p dist-arm64
+          ./build_dmg.sh \
+            --app-path build/filterGenerator/filterGenerator.app \
+            --output "dist-arm64/filterGenerator-macos-arm64.dmg" \
+            --volname "FilterGenerator (arm64)"
+          ./build_dmg.sh \
+            --app-path build/filterGenerator/filterRuleTest.app \
+            --output "dist-arm64/filterRuleTest-macos-arm64.dmg" \
+            --volname "FilterRuleTest (arm64)"
           echo "name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
-          echo "Package created: ${ARTIFACT_NAME}.tar.gz ($(du -sh ../../${ARTIFACT_NAME}.tar.gz | cut -f1))"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: filterGenerator-macos-arm64
-          path: filterGenerator-macos-arm64.tar.gz
+          path: dist-arm64/*.dmg
           retention-days: 30
 
   build-mac-x86_64:
@@ -124,18 +130,24 @@ jobs:
           macdeployqt build/filterGenerator/filterGenerator.app -verbose=1
           macdeployqt build/filterGenerator/filterRuleTest.app -verbose=1
 
-      - name: Package
+      - name: Package as DMG
         id: set-artifact
         run: |
           ARTIFACT_NAME="filterGenerator-macos-x86_64"
-          cd build/filterGenerator
-          tar -czf "../../${ARTIFACT_NAME}.tar.gz" filterGenerator.app filterRuleTest.app
+          mkdir -p dist-x86_64
+          ./build_dmg.sh \
+            --app-path build/filterGenerator/filterGenerator.app \
+            --output "dist-x86_64/filterGenerator-macos-x86_64.dmg" \
+            --volname "FilterGenerator (x86_64)"
+          ./build_dmg.sh \
+            --app-path build/filterGenerator/filterRuleTest.app \
+            --output "dist-x86_64/filterRuleTest-macos-x86_64.dmg" \
+            --volname "FilterRuleTest (x86_64)"
           echo "name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
-          echo "Package created: ${ARTIFACT_NAME}.tar.gz ($(du -sh ../../${ARTIFACT_NAME}.tar.gz | cut -f1))"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: filterGenerator-macos-x86_64
-          path: filterGenerator-macos-x86_64.tar.gz
+          path: dist-x86_64/*.dmg
           retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,13 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: "CGE Tools ${{ steps.prerelease.outputs.tag }}"
+          draft: false
           prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
           generate_release_notes: true
           make_latest: ${{ steps.prerelease.outputs.is_prerelease == 'false' }}
           fail_on_unmatched_files: false
           files: |
+            artifacts/**/*.dmg
             artifacts/**/*.tar.gz
             artifacts/**/*.AppImage
             artifacts/**/*.zip

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # CGE-Tools
 
+[![Release](https://github.com/wysaid/cge-tools/actions/workflows/release.yml/badge.svg)](https://github.com/wysaid/cge-tools/actions/workflows/release.yml)
+[![macOS Build](https://github.com/wysaid/cge-tools/actions/workflows/macos-build.yml/badge.svg)](https://github.com/wysaid/cge-tools/actions/workflows/macos-build.yml)
+[![Linux Build](https://github.com/wysaid/cge-tools/actions/workflows/linux-build.yml/badge.svg)](https://github.com/wysaid/cge-tools/actions/workflows/linux-build.yml)
+[![Windows Build](https://github.com/wysaid/cge-tools/actions/workflows/windows-build.yml/badge.svg)](https://github.com/wysaid/cge-tools/actions/workflows/windows-build.yml)
+
 A powerful C++ image and video processing library with OpenGL-based filters and effects, built with Qt5/Qt6 support.
 
 ## Quick Links

--- a/build_dmg.sh
+++ b/build_dmg.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# build_dmg.sh — Deploy Qt deps and package .app bundle(s) into .dmg files.
+#
+# Default (no args):
+#   1. Runs macdeployqt on filterGenerator.app and filterRuleTest.app found in
+#      ./build/filterGenerator/.
+#   2. Resolves symlinks in each app's Frameworks/ directory.
+#   3. Packages each .app into a .dmg and writes them into ./build/.
+#
+# Single-app mode:
+#   ./build_dmg.sh --app-path <path/to/App.app> --output <path/to/output.dmg>
+#   (macdeployqt is NOT run automatically — caller is responsible)
+#
+# Options:
+#   --app-path PATH   Path to the .app bundle (single-app mode)
+#   --output   PATH   Destination .dmg file path (single-app mode)
+#   --volname  NAME   Volume name when the DMG is mounted
+#                     (default: basename of the .app without extension)
+#   --no-deploy       Skip macdeployqt step (default mode only)
+#   --no-sign         Skip ad-hoc code signing step
+#   -h, --help        Show this help and exit
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+APP_PATH=""
+OUTPUT_PATH=""
+VOLNAME=""
+SKIP_SIGN=false
+SKIP_DEPLOY=false
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --app-path)
+        APP_PATH="$2"
+        shift 2
+        ;;
+    --output)
+        OUTPUT_PATH="$2"
+        shift 2
+        ;;
+    --volname)
+        VOLNAME="$2"
+        shift 2
+        ;;
+    --no-deploy)
+        SKIP_DEPLOY=true
+        shift
+        ;;
+    --no-sign)
+        SKIP_SIGN=true
+        shift
+        ;;
+    -h | --help)
+        sed -n '2,22p' "$0" | sed 's/^# \?//'
+        exit 0
+        ;;
+    *)
+        echo "Unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+done
+
+# ── Locate macdeployqt ────────────────────────────────────────────────────────
+find_macdeployqt() {
+    local _BIN
+    _BIN="$(command -v macdeployqt 2>/dev/null || true)"
+    if [[ -z "$_BIN" ]] && [[ -n "${QTDIR:-}" ]]; then
+        _BIN="$QTDIR/bin/macdeployqt"
+    fi
+    if [[ -z "$_BIN" ]] && [[ -n "${QT_DIR:-}" ]]; then
+        _BIN="$QT_DIR/bin/macdeployqt"
+    fi
+    # Homebrew fallback
+    if [[ -z "$_BIN" ]]; then
+        _BIN="$(find /opt/homebrew /usr/local -maxdepth 5 -name macdeployqt -type f 2>/dev/null | head -1 || true)"
+    fi
+    echo "$_BIN"
+}
+
+# ── Resolve symlinks inside Frameworks/ (hdiutil can choke on broken symlinks) ──
+resolve_frameworks_symlinks() {
+    local _FW_DIR="$1/Contents/Frameworks"
+    [[ -d "$_FW_DIR" ]] || return 0
+    local _F _REAL
+    for _F in "$_FW_DIR"/*; do
+        if [[ -L "$_F" ]]; then
+            _REAL="$(realpath "$_F")"
+            rm "$_F"
+            cp -r "$_REAL" "$_F"
+            echo "  resolved symlink: $(basename "$_F")"
+        fi
+    done
+}
+
+# ── Run macdeployqt on a single .app ─────────────────────────────────────────
+deploy_app() {
+    local _APP="$1"
+    local _QDEPLOY
+    _QDEPLOY="$(find_macdeployqt)"
+
+    if [[ -z "$_QDEPLOY" ]] || [[ ! -x "$_QDEPLOY" ]]; then
+        echo "Error: macdeployqt not found. Set QTDIR or add it to PATH." >&2
+        return 1
+    fi
+
+    echo "→ macdeployqt: $_APP"
+    "$_QDEPLOY" "$_APP" -verbose=1
+
+    echo "  Resolving Frameworks symlinks..."
+    resolve_frameworks_symlinks "$_APP"
+}
+
+# ── Core DMG packaging function ───────────────────────────────────────────────
+# package_dmg <app_path> <output_path> [volname]
+package_dmg() {
+    local _APP="$1"
+    local _OUT="$2"
+    local _VOL="${3:-$(basename "$_APP" .app)}"
+
+    if [[ ! -d "$_APP" ]]; then
+        echo "Error: .app bundle not found at: $_APP" >&2
+        return 1
+    fi
+
+    _APP="$(cd "$_APP" && pwd)"   # absolute path
+    mkdir -p "$(dirname "$_OUT")"
+
+    # Remove dangling .DS_Store symlinks left by macdeployqt
+    find "$_APP" -name '.DS_Store' -type l -delete 2>/dev/null || true
+
+    # Ad-hoc code sign
+    if ! $SKIP_SIGN; then
+        echo "→ Signing (ad-hoc): $_APP"
+        if ! codesign --force --deep --sign - "$_APP"; then
+            echo "Warning: codesign failed — continuing without signing." >&2
+        else
+            echo "  Signing complete."
+        fi
+    fi
+
+    # Remove pre-existing DMG so hdiutil does not prompt
+    [[ -f "$_OUT" ]] && rm -f "$_OUT"
+
+    echo "→ Creating DMG: $_OUT"
+    hdiutil create \
+        -volname "$_VOL" \
+        -srcfolder "$_APP" \
+        -ov \
+        -format ULMO \
+        "$_OUT"
+
+    echo "✓ DMG ready: $_OUT ($(du -sh "$_OUT" | cut -f1))"
+}
+
+# ── Default mode (no --app-path / --output provided) ─────────────────────────
+if [[ -z "$APP_PATH" ]] && [[ -z "$OUTPUT_PATH" ]]; then
+    BUILD_DIR="$SCRIPT_DIR/build"
+    FG_DIR="$BUILD_DIR/filterGenerator"
+
+    echo "=== Default mode: packaging Release builds from $FG_DIR ==="
+
+    FAILED=0
+    for APP in \
+        "$FG_DIR/filterGenerator.app" \
+        "$FG_DIR/filterRuleTest.app"
+    do
+        if [[ ! -d "$APP" ]]; then
+            echo "Skipping (not found): $APP"
+            continue
+        fi
+
+        APP_BASE="$(basename "$APP" .app)"
+
+        # Deploy Qt deps unless explicitly skipped
+        if ! $SKIP_DEPLOY; then
+            deploy_app "$APP" || { FAILED=1; continue; }
+        fi
+
+        package_dmg "$APP" "$BUILD_DIR/${APP_BASE}.dmg" || FAILED=1
+    done
+
+    if [[ $FAILED -eq 1 ]]; then
+        echo "One or more DMG builds failed." >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+# ── Single-app mode ───────────────────────────────────────────────────────────
+if [[ -z "$APP_PATH" ]] || [[ -z "$OUTPUT_PATH" ]]; then
+    echo "Error: --app-path and --output must be specified together." >&2
+    exit 1
+fi
+
+# In single-app mode macdeployqt is the caller's responsibility (e.g. CI).
+package_dmg "$APP_PATH" "$OUTPUT_PATH" "$VOLNAME"

--- a/build_dmg.sh
+++ b/build_dmg.sh
@@ -126,7 +126,7 @@ package_dmg() {
         return 1
     fi
 
-    _APP="$(cd "$_APP" && pwd)"   # absolute path
+    _APP="$(cd "$_APP" && pwd)" # absolute path
     mkdir -p "$(dirname "$_OUT")"
 
     # Remove dangling .DS_Store symlinks left by macdeployqt
@@ -146,12 +146,29 @@ package_dmg() {
     [[ -f "$_OUT" ]] && rm -f "$_OUT"
 
     echo "→ Creating DMG: $_OUT"
-    hdiutil create \
-        -volname "$_VOL" \
-        -srcfolder "$_APP" \
-        -ov \
-        -format ULMO \
-        "$_OUT"
+    # hdiutil can spuriously report "Resource busy" on GitHub Actions runners
+    # when two invocations occur back-to-back.  Retry with exponential back-off.
+    local _MAX_RETRIES=5
+    local _DELAY=2
+    local _ATTEMPT=1
+    while true; do
+        if hdiutil create \
+            -volname "$_VOL" \
+            -srcfolder "$_APP" \
+            -ov \
+            -format ULMO \
+            "$_OUT"; then
+            break
+        fi
+        if [[ $_ATTEMPT -ge $_MAX_RETRIES ]]; then
+            echo "Error: hdiutil create failed after $_MAX_RETRIES attempts." >&2
+            return 1
+        fi
+        echo "  hdiutil failed (attempt $_ATTEMPT/$_MAX_RETRIES) — retrying in ${_DELAY}s..." >&2
+        sleep "$_DELAY"
+        _DELAY=$((_DELAY * 2))
+        _ATTEMPT=$((_ATTEMPT + 1))
+    done
 
     echo "✓ DMG ready: $_OUT ($(du -sh "$_OUT" | cut -f1))"
 }
@@ -166,8 +183,7 @@ if [[ -z "$APP_PATH" ]] && [[ -z "$OUTPUT_PATH" ]]; then
     FAILED=0
     for APP in \
         "$FG_DIR/filterGenerator.app" \
-        "$FG_DIR/filterRuleTest.app"
-    do
+        "$FG_DIR/filterRuleTest.app"; do
         if [[ ! -d "$APP" ]]; then
             echo "Skipping (not found): $APP"
             continue
@@ -177,7 +193,10 @@ if [[ -z "$APP_PATH" ]] && [[ -z "$OUTPUT_PATH" ]]; then
 
         # Deploy Qt deps unless explicitly skipped
         if ! $SKIP_DEPLOY; then
-            deploy_app "$APP" || { FAILED=1; continue; }
+            deploy_app "$APP" || {
+                FAILED=1
+                continue
+            }
         fi
 
         package_dmg "$APP" "$BUILD_DIR/${APP_BASE}.dmg" || FAILED=1

--- a/build_dmg.sh
+++ b/build_dmg.sh
@@ -34,14 +34,29 @@ SKIP_DEPLOY=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
     --app-path)
+        if [[ $# -lt 2 ]] || [[ "$2" == --* ]]; then
+            echo "Error: --app-path requires a value." >&2
+            sed -n '2,22p' "$0" | sed 's/^# \?//'
+            exit 1
+        fi
         APP_PATH="$2"
         shift 2
         ;;
     --output)
+        if [[ $# -lt 2 ]] || [[ "$2" == --* ]]; then
+            echo "Error: --output requires a value." >&2
+            sed -n '2,22p' "$0" | sed 's/^# \?//'
+            exit 1
+        fi
         OUTPUT_PATH="$2"
         shift 2
         ;;
     --volname)
+        if [[ $# -lt 2 ]] || [[ "$2" == --* ]]; then
+            echo "Error: --volname requires a value." >&2
+            sed -n '2,22p' "$0" | sed 's/^# \?//'
+            exit 1
+        fi
         VOLNAME="$2"
         shift 2
         ;;
@@ -88,7 +103,14 @@ resolve_frameworks_symlinks() {
     local _F _REAL
     for _F in "$_FW_DIR"/*; do
         if [[ -L "$_F" ]]; then
-            _REAL="$(realpath "$_F")"
+            if ! _REAL="$(realpath "$_F" 2>/dev/null)"; then
+                echo "  warning: failed to resolve symlink $(basename "$_F"); leaving as-is" >&2
+                continue
+            fi
+            if [[ ! -e "$_REAL" ]]; then
+                echo "  warning: target of symlink $(basename "$_F") does not exist: $_REAL" >&2
+                continue
+            fi
             rm "$_F"
             cp -r "$_REAL" "$_F"
             echo "  resolved symlink: $(basename "$_F")"
@@ -131,6 +153,10 @@ package_dmg() {
 
     # Remove dangling .DS_Store symlinks left by macdeployqt
     find "$_APP" -name '.DS_Store' -type l -delete 2>/dev/null || true
+
+    # Resolve Frameworks symlinks (hdiutil can choke on broken symlinks)
+    echo "  Resolving Frameworks symlinks..."
+    resolve_frameworks_symlinks "$_APP"
 
     # Ad-hoc code sign
     if ! $SKIP_SIGN; then

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,22 @@
+# CGE Tools — Pre-built Binaries
+
+> [!WARNING]
+> **The pre-built binaries in this directory are deprecated and no longer maintained.**
+> They were provided for historical reference only and may be outdated.
+
+## Download Latest Release
+
+Please download the latest pre-built binaries from the **GitHub Releases page**:
+
+👉 **[https://github.com/wysaid/cge-tools/releases](https://github.com/wysaid/cge-tools/releases)**
+
+Each release provides:
+
+- **macOS** — arm64 (Apple Silicon) and x86_64 (Intel) builds
+- **Linux** — Ubuntu 22.04 and Fedora packages (`.tar.gz` / `.AppImage`)
+- **Windows** — x64 MSVC build (`.zip`)
+
+## Building from Source
+
+If no pre-built binary is available for your platform, see the
+[Build Documentation](../docs/BUILD.md) or the [Quick Start Guide](../docs/QUICKSTART.md).


### PR DESCRIPTION
## Summary

Improves the macOS release experience by packaging apps as DMG files and fixing several issues in the release workflow.

## Changes

### `build_dmg.sh` (new)
- Reusable script that wraps the full macOS packaging pipeline
- **Default mode** (no args): auto-runs `macdeployqt`, resolves `Frameworks/` symlinks (prevents broken symlinks in DMG), ad-hoc signs, and creates a DMG via `hdiutil` — targets `filterGenerator.app` and `filterRuleTest.app` in `./build/`
- **Single-app mode** (`--app-path` / `--output`): used by CI where `macdeployqt` runs in a dedicated prior step
- Flags: `--no-deploy`, `--no-sign`, `--volname`, `-h`

### `.github/workflows/macos-build.yml`
- Replace `tar -czf` packaging with DMG packaging via `build_dmg.sh` for both `arm64` and `x86_64` jobs
- `macdeployqt` step is retained as a separate step before packaging (CI already had it; single-app mode does not re-run it)

### `.github/workflows/release.yml`
- Add `draft: false` — releases now publish immediately without requiring manual promotion from draft state
- Add `artifacts/**/*.dmg` to the `files:` glob so macOS DMGs are attached to the GitHub Release page

### `tools/README.md` (new)
- Deprecation notice for pre-built binaries in `tools/`; directs users to the GitHub Releases page

### `README.md`
- Add CI status badges: Release, macOS Build, Linux Build, Windows Build

## Testing

- Locally verified `./build_dmg.sh` default mode: produces 29 MB DMGs with Qt frameworks correctly embedded (was 1.3 MB without `macdeployqt`)
- CI workflow structure unchanged — `macdeployqt` step runs before `build_dmg.sh` in single-app mode
